### PR TITLE
Added 'joint state publisher gui' exec dependency

### DIFF
--- a/turtlebot3_automatic_parking_vision/package.xml
+++ b/turtlebot3_automatic_parking_vision/package.xml
@@ -23,6 +23,7 @@
   <depend>ar_track_alvar_msgs</depend>
   <depend>ar_track_alvar</depend>
   <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
   <exec_depend>turtlebot3_bringup</exec_depend>


### PR DESCRIPTION
If you launch the `turtlebot3_automatic_parking_vision.launch` launch file, you get the following error:

```
[WARN] [1604913455.107822, 31.792000]: The 'use_gui' parameter was specified, which is deprecated.  We'll attempt to find and run the GUI, but if this fails you should install the 'joint_state_publisher_gui' package instead and run that.  This backwards compatibility option will be removed in Noetic.
[ERROR] [1604913455.109143, 31.794000]: Could not find the GUI, install the 'joint_state_publisher_gui' package
```

I added the dependency for the gui, to make sure it gets installed using rosdep.
