### PR TITLE
Release build error fix

### DIFF
--- a/.github/workflows/ros-ci.yml
+++ b/.github/workflows/ros-ci.yml
@@ -49,6 +49,23 @@ jobs:
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 
+      - name: Check and Install ROS dependencies
+        shell: bash
+        run: |
+          set -e
+          source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
+          echo "--- Updating rosdep definitions ---"
+          rosdep update
+          echo "--- Installing system dependencies for ROS 2 ${{ matrix.ros_distribution }} ---"
+          rosdep install --from-paths ros_ws/src --ignore-src -y -r --rosdistro ${{ matrix.ros_distribution }}
+          echo "--- Performing rosdep check for ROS 2 ${{ matrix.ros_distribution }} ---"
+          if rosdep check --from-paths ros_ws/src --ignore-src --rosdistro ${{ matrix.ros_distribution }}; then
+            echo "--- rosdep check passed ---"
+          else
+            echo "--- rosdep check failed: Missing system dependencies or unresolvable keys. ---"
+            exit 1
+          fi
+
       - name: Build and Test
         uses: ros-tooling/action-ros-ci@v0.3
         with:

--- a/turtlebot3_follower/package.xml
+++ b/turtlebot3_follower/package.xml
@@ -17,6 +17,9 @@
   <depend>nav2_msgs</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/turtlebot3_panorama/package.xml
+++ b/turtlebot3_panorama/package.xml
@@ -20,6 +20,7 @@
   <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>
   <depend>image_transport</depend>
+  <depend>libboost-system-dev</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
### CHANGE
- Add libboost-system-dev in packge.xml of turtlebot3_panorama
- Add tf2, tf2-ros, tf2-geometry-msgs in package.xml of turtlebot3_follower
### ERROR LOG
- humble
---
```
17:49:09 CMake Error at /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake:141 (find_package):
17:49:09   Could not find a package configuration file provided by "boost_system"
17:49:09   (requested version 1.74.0) with any of the following names:
17:49:09 
17:49:09     boost_systemConfig.cmake
17:49:09     boost_system-config.cmake
17:49:09 
17:49:09   Add the installation prefix of "boost_system" to CMAKE_PREFIX_PATH or set
17:49:09   "boost_system_DIR" to a directory containing one of the above files.  If
17:49:09   "boost_system" provides a separate development package or SDK, be sure it
17:49:09   has been installed.
17:49:09 Call Stack (most recent call first):
17:49:09   /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake:258 (boost_find_component)
17:49:09   /usr/share/cmake-3.22/Modules/FindBoost.cmake:594 (find_package)
17:49:09   CMakeLists.txt:29 (find_package)
```
---
- jazzy
```
18:32:52 CMake Error at CMakeLists.txt:21 (find_package):
18:32:52   By not providing "Findtf2_geometry_msgs.cmake" in CMAKE_MODULE_PATH this
18:32:52   project has asked CMake to find a package configuration file provided by
18:32:52   "tf2_geometry_msgs", but CMake did not find one.
18:32:52 
18:32:52   Could not find a package configuration file provided by "tf2_geometry_msgs"
18:32:52   with any of the following names:
18:32:52 
18:32:52     tf2_geometry_msgsConfig.cmake
18:32:52     tf2_geometry_msgs-config.cmake
18:32:52 
18:32:52   Add the installation prefix of "tf2_geometry_msgs" to CMAKE_PREFIX_PATH or
18:32:52   set "tf2_geometry_msgs_DIR" to a directory containing one of the above
18:32:52   files.  If "tf2_geometry_msgs" provides a separate development package or
18:32:52   SDK, be sure it has been installed.
```